### PR TITLE
Merge apt-get update & install and add python-dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,8 @@ FROM phusion/baseimage:0.9.18
 # Install Dependencies
 # ------------------------------------------------------------------------------
 
-RUN apt-get update 
-RUN apt-get install -y make \
+RUN apt-get update && \
+    apt-get install -y make \
 	wget \
 	unrar \ 
 	autoconf \ 
@@ -21,6 +21,7 @@ RUN apt-get install -y make \
 	ncurses-dev \ 
 	libexpat-dev \ 
 	python \
+	python-dev \
 	python-serial \ 
 	sed \
 	git \


### PR DESCRIPTION
Merge apt-get update & install in single RUN and add dependency on python-dev

Didn't test the generated container yet, but without python-dev the build of the container fails, now it builds.