### PR TITLE
Alternative header handling

### DIFF
--- a/Sming/Components/MultipartParser/MultipartParser.h
+++ b/Sming/Components/MultipartParser/MultipartParser.h
@@ -33,9 +33,9 @@ public:
 	static int bodyEnd(multipart_parser_t* p);
 
 private:
-	multipart_parser_settings_t settings;
+	static multipart_parser_settings_t settings;
 
-	bool useValue = false;
+	String headerName; ///< Current header field name
 
 	HttpRequest* request = nullptr;
 


### PR DESCRIPTION
As a suggestion, if we keep a note of `headerName` the code is clearer and more flexible if we want to check other header fields.

Throwing a junk file at it I get this (emulator):

```
8969445 TCP received: 536 bytes
8969445 TCP onReadyToSendData: 1
8969445 The headers are complete
8969445 Mapped 'firmware' @ 0x00002000
8970422 TCP received: 107 bytes
8970422 TCP onReadyToSendData: 1
8972374 partBegin
8972374 readHeaderName('Content-Disposition')
8972374 readHeaderValue('form-data; name="firmware"; filename="App_Common.c"')
8972374 parser->name = 'firmware'
8972374 readHeaderName('Content-Type')
8972374 readHeaderValue('text/x-csrc')
8972374 partData(2 bytes)
flashmem_write: 0x00002000, 0
8972374 rboot_write_flash: item.size: 3
8973351 partData(2 bytes)
flashmem_write: 0x00002000, 4
8973351 rboot_write_flash: item.size: 5
8973351 partData(0 bytes)
8973351 rboot_write_flash: item.size: 5
8973351 partData(2 bytes)
flashmem_write: 0x00002004, 0
8973351 rboot_write_flash: item.size: 7
```