### PR TITLE
Add certificate DN parsing for BR implementation

### DIFF
--- a/Sming/Components/ssl/Axtls/AxCertificate.cpp
+++ b/Sming/Components/ssl/Axtls/AxCertificate.cpp
@@ -1,0 +1,56 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * AxCertificate.cpp
+ *
+ ****/
+
+#include "AxCertificate.h"
+
+namespace Ssl
+{
+String AxCertificate::getName(DN dn, RDN rdn) const
+{
+	if(ssl == nullptr || ssl->x509_ctx == nullptr) {
+		return nullptr;
+	}
+
+	int dnType;
+	switch(rdn) {
+	case RDN::COMMON_NAME:
+		dnType = X509_COMMON_NAME;
+		break;
+	case RDN::ORGANIZATION_NAME:
+		dnType = X509_ORGANIZATION;
+		break;
+	case RDN::ORGANIZATIONAL_UNIT_NAME:
+		dnType = X509_ORGANIZATIONAL_UNIT;
+		break;
+	case RDN::LOCALITY_NAME:
+		dnType = X509_LOCATION;
+		break;
+	case RDN::COUNTRY_NAME:
+		dnType = X509_COUNTRY;
+		break;
+	case RDN::STATE_OR_PROVINCE_NAME:
+		dnType = X509_STATE;
+		break;
+	default:
+		return nullptr;
+	}
+
+	switch(dn) {
+	case DN::ISSUER:
+		return ssl->x509_ctx->ca_cert_dn[dnType];
+
+	case DN::SUBJECT:
+		return ssl->x509_ctx->cert_dn[dnType];
+	default:
+		return nullptr;
+	}
+}
+
+} // namespace Ssl

--- a/Sming/Components/ssl/Axtls/AxCertificate.h
+++ b/Sming/Components/ssl/Axtls/AxCertificate.h
@@ -40,10 +40,7 @@ public:
 		return (ssl_match_spki_sha256(ssl, hash) == 0);
 	}
 
-	const String getName(Name name) const override
-	{
-		return String(ssl_get_cert_dn(ssl, int(name)));
-	}
+	String getName(DN dn, RDN rdn) const override;
 
 private:
 	SSL* ssl;

--- a/Sming/Components/ssl/Axtls/AxConnection.cpp
+++ b/Sming/Components/ssl/Axtls/AxConnection.cpp
@@ -18,6 +18,7 @@
  *
  ****/
 
+#include <SslDebug.h>
 #include "AxConnection.h"
 #include "AxContext.h"
 #include <Network/Ssl/Session.h>
@@ -33,16 +34,12 @@ int AxConnection::write(const uint8_t* data, size_t length)
 
 	int available = tcp_sndbuf(tcp);
 	if(available < required) {
-#ifdef SSL_DEBUG
 		debug_i("SSL: Required: %d, Available: %d", required, available);
-#endif
 		return SSL_NOT_OK;
 	}
 
 	int written = ssl_write(ssl, data, length);
-#ifdef SSL_DEBUG
 	debug_d("SSL: Write len: %d, Written: %d", length, written);
-#endif
 	if(written < 0) {
 		debug_e("SSL: Write Error: %d", written);
 	}

--- a/Sming/Components/ssl/BearSsl/Asn1Parser.h
+++ b/Sming/Components/ssl/BearSsl/Asn1Parser.h
@@ -1,0 +1,144 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Asn1Parser.h
+ *
+ * A very simple helper class consisting of code based on asn1_name() in axTLS.
+ *
+ ****/
+
+#pragma once
+
+#include <stdint.h>
+
+enum ASN1 {
+	ASN1_BOOLEAN = 0x01,
+	ASN1_INTEGER = 0x02,
+	ASN1_BIT_STRING = 0x03,
+	ASN1_OCTET_STRING = 0x04,
+	ASN1_NULL = 0x05,
+	ASN1_OID = 0x06,
+	ASN1_PRINTABLE_STR2 = 0x0c,
+	ASN1_PRINTABLE_STR = 0x13,
+	ASN1_TELETEX_STR = 0x14,
+	ASN1_IA5_STR = 0x16,
+	ASN1_UTC_TIME = 0x17,
+	ASN1_GENERALIZED_TIME = 0x18,
+	ASN1_UNICODE_STR = 0x1e,
+	ASN1_SEQUENCE = 0x30,
+	ASN1_SET = 0x31,
+	ASN1_IMPLICIT_TAG = 0x80,
+	ASN1_CONTEXT_DNSNAME = 0x82,
+	ASN1_EXPLICIT_TAG = 0xa0,
+	ASN1_V3_DATA = 0xa3,
+};
+
+class Asn1Parser
+{
+public:
+	Asn1Parser(const uint8_t* data, unsigned length) : buf(data), length(length)
+	{
+	}
+
+	unsigned getOffset() const
+	{
+		return offset;
+	}
+
+	void setOffset(unsigned offset)
+	{
+		this->offset = offset;
+	}
+
+	unsigned getLength()
+	{
+		if((buf[offset] & 0x80) == 0) {
+			return buf[offset++];
+		}
+
+		unsigned lengthBytes = buf[offset++] & 0x7f;
+		if(lengthBytes > 4) {
+			return 0;
+		}
+
+		uint32_t len = 0;
+		for(unsigned i = 0; i < lengthBytes; i++) {
+			len <<= 8;
+			len += buf[offset++];
+		}
+
+		return len;
+	}
+
+	// Skip the ASN1.1 object type and its length. Get ready to read the object's data.
+	unsigned getNextObject(uint8_t objType)
+	{
+		if(offset >= length || buf[offset] != objType) {
+			return 0;
+		}
+
+		++offset;
+		return getLength();
+	}
+
+	// Get the components of a distinguished name
+	uint8_t getObjectId()
+	{
+		auto len = getNextObject(ASN1_OID);
+		if(len == 0) {
+			return 0;
+		}
+
+		uint8_t dnType = 0;
+
+		/* expect a sequence of 2.5.4.[x] where x is a one of distinguished name
+	       components we are interested in. */
+		if(len == 3 && buf[offset] == 0x55 && buf[offset + 1] == 0x04) {
+			dnType = buf[offset + 2];
+		}
+
+		// Skip it
+		offset += len;
+		return dnType;
+	}
+
+	// Extract a readable string
+	String getString()
+	{
+		auto asn1_type = buf[offset];
+
+		++offset;
+		auto len = getLength();
+
+		String s;
+		switch(asn1_type) {
+		case ASN1_UNICODE_STR:
+			len /= 2;
+			s.setLength(len);
+			for(unsigned i = 0; i < len; ++i) {
+				// Unicode MSB first
+				s[i] = buf[offset + 1];
+				offset += 2;
+			}
+			break;
+
+		case ASN1_PRINTABLE_STR:
+		case ASN1_PRINTABLE_STR2:
+		case ASN1_TELETEX_STR:
+		case ASN1_IA5_STR:
+			s.setString(reinterpret_cast<const char*>(&buf[offset]), len);
+			offset += len;
+			break;
+		}
+
+		return s;
+	}
+
+private:
+	const uint8_t* buf;
+	unsigned length;
+	unsigned offset = 0;
+};

--- a/Sming/Components/ssl/BearSsl/BrCertificate.cpp
+++ b/Sming/Components/ssl/BearSsl/BrCertificate.cpp
@@ -1,0 +1,37 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * BrCertificate.cpp
+ *
+ ****/
+
+#include "BrCertificate.h"
+#include <FlashString/Array.hpp>
+
+namespace Ssl
+{
+String BrCertificate::getName(DN dn, RDN rdn) const
+{
+#define XX(tag, a, b, c, d) d,
+	DEFINE_FSTR_ARRAY_LOCAL(rdnTypes, uint8_t, SSL_X509_RDN_OID_MAP(XX));
+#undef XX
+
+	uint8_t type = rdnTypes[unsigned(rdn)];
+	if(type == 0) {
+		return nullptr;
+	}
+
+	switch(dn) {
+	case DN::ISSUER:
+		return context->getIssuer().getRDN(type);
+	case DN::SUBJECT:
+		return context->getSubject().getRDN(type);
+	default:
+		return nullptr;
+	}
+}
+
+} // namespace Ssl

--- a/Sming/Components/ssl/BearSsl/BrCertificate.h
+++ b/Sming/Components/ssl/BearSsl/BrCertificate.h
@@ -4,9 +4,7 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * X509Context.h
- *
- * @author: 2019 - Slavey Karadzhov <slav@attachix.com>
+ * BrCertificate.h
  *
  ****/
 
@@ -14,28 +12,31 @@
 
 #include <Network/Ssl/Certificate.h>
 #include <Network/Ssl/Crypto.h>
+#include "X509Context.h"
 
 namespace Ssl
 {
 class BrCertificate : public Ssl::Certificate
 {
 public:
-	uint8_t sha1Hash[SHA1_SIZE];
+	BrCertificate(X509Context* context) : context(context)
+	{
+	}
 
 	bool matchFingerprint(const uint8_t* hash) const override
 	{
-		return memcmp(hash, sha1Hash, SHA1_SIZE) == 0;
+		return context->matchFingerprint(hash);
 	}
 
 	bool matchPki(const uint8_t* hash) const override
 	{
-		return false;
+		return context->matchPki(hash);
 	}
 
-	const String getName(Name name) const override
-	{
-		return nullptr;
-	}
+	String getName(DN dn, RDN rdn) const override;
+
+private:
+	X509Context* context;
 };
 
 } // namespace Ssl

--- a/Sming/Components/ssl/BearSsl/BrClientConnection.cpp
+++ b/Sming/Components/ssl/BearSsl/BrClientConnection.cpp
@@ -38,14 +38,4 @@ int BrClientConnection::init()
 	return startHandshake();
 }
 
-const Certificate* BrClientConnection::getCertificate() const
-{
-	if(certificate == nullptr) {
-		certificate = new BrCertificate();
-		x509Context->getCertificateHash(certificate->sha1Hash);
-	}
-
-	return certificate;
-}
-
 } // namespace Ssl

--- a/Sming/Components/ssl/BearSsl/BrClientConnection.cpp
+++ b/Sming/Components/ssl/BearSsl/BrClientConnection.cpp
@@ -12,7 +12,7 @@
 
 /*
  */
-#include "debug.h"
+#include <SslDebug.h>
 #include "BrClientConnection.h"
 #include <Network/Ssl/Session.h>
 

--- a/Sming/Components/ssl/BearSsl/BrClientConnection.h
+++ b/Sming/Components/ssl/BearSsl/BrClientConnection.h
@@ -30,7 +30,14 @@ public:
 
 	int init();
 
-	const Certificate* getCertificate() const override;
+	const Certificate* getCertificate() const override
+	{
+		if(certificate == nullptr) {
+			certificate = new BrCertificate(x509Context);
+		}
+
+		return certificate;
+	}
 
 	void freeCertificate() override
 	{

--- a/Sming/Components/ssl/BearSsl/BrConnection.cpp
+++ b/Sming/Components/ssl/BearSsl/BrConnection.cpp
@@ -12,7 +12,7 @@
 
 /*
  */
-#include "debug.h"
+#include <SslDebug.h>
 #include "BrConnection.h"
 #include <Network/Ssl/Session.h>
 #include <FlashString/Array.hpp>

--- a/Sming/Components/ssl/BearSsl/BrServerConnection.cpp
+++ b/Sming/Components/ssl/BearSsl/BrServerConnection.cpp
@@ -12,7 +12,7 @@
 
 /*
  */
-#include "debug.h"
+#include <SslDebug.h>
 #include "BrServerConnection.h"
 #include <Network/Ssl/Session.h>
 

--- a/Sming/Components/ssl/BearSsl/BrServerKey.cpp
+++ b/Sming/Components/ssl/BearSsl/BrServerKey.cpp
@@ -8,7 +8,7 @@
  *
  ****/
 
-#include "debug.h"
+#include <SslDebug.h>
 #include "BrServerKey.h"
 
 namespace Ssl

--- a/Sming/Components/ssl/BearSsl/X509Context.cpp
+++ b/Sming/Components/ssl/BearSsl/X509Context.cpp
@@ -1,3 +1,13 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * X509Context.cpp
+ *
+ ****/
+
 #include "X509Context.h"
 #include "BrConnection.h"
 

--- a/Sming/Components/ssl/BearSsl/X509Context.cpp
+++ b/Sming/Components/ssl/BearSsl/X509Context.cpp
@@ -19,21 +19,12 @@ const br_x509_class X509Context::vt PROGMEM = {
 
 void X509Context::startChain(const char* serverName)
 {
-	auto subject_dn_append = [](void* ctx, const void* buf, size_t len) {
-		GET_SELF();
-		br_sha256_update(&self->subjectSha256, buf, len);
-	};
-
-	auto issuer_dn_append = [](void* ctx, const void* buf, size_t len) {
-		GET_SELF();
-		br_sha256_update(&self->issuerSha256, buf, len);
-	};
-
-	br_x509_decoder_init(&x509Decoder, subject_dn_append, this, issuer_dn_append, this);
+	br_x509_decoder_init(&x509Decoder, subject.append, &subject, issuer.append, &issuer);
 	certificateCount = 0;
 	br_sha1_init(&certificateSha1);
-	br_sha256_init(&subjectSha256);
-	br_sha256_init(&issuerSha256);
+	issuer.clear();
+	subject.clear();
+	debug_i("X509Context: serverName = \"%s\"", serverName);
 	(void)serverName;
 }
 

--- a/Sming/Components/ssl/BearSsl/X509Context.h
+++ b/Sming/Components/ssl/BearSsl/X509Context.h
@@ -6,13 +6,11 @@
  *
  * X509Context.h
  *
- * @author: 2019 - Slavey Karadzhov <slav@attachix.com>
- *
  ****/
 
 #pragma once
 
-#include "debug.h"
+#include <SslDebug.h>
 #include <bearssl.h>
 
 namespace Ssl

--- a/Sming/Components/ssl/BearSsl/X509Context.h
+++ b/Sming/Components/ssl/BearSsl/X509Context.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include <SslDebug.h>
-#include <bearssl.h>
+#include "X509Name.h"
 
 namespace Ssl
 {
@@ -31,22 +31,27 @@ public:
 		return &vtable;
 	}
 
-	uint8_t* getIssuerHash(uint8_t hash[br_sha256_SIZE])
+	const X509Name& getIssuer() const
 	{
-		br_sha256_out(&issuerSha256, hash);
-		return hash;
+		return issuer;
 	}
 
-	uint8_t* getSubjectHash(uint8_t hash[br_sha256_SIZE])
+	const X509Name& getSubject() const
 	{
-		br_sha256_out(&subjectSha256, hash);
-		return hash;
+		return subject;
 	}
 
-	uint8_t* getCertificateHash(uint8_t hash[br_sha1_SIZE])
+	bool matchFingerprint(const uint8_t* sha1Hash) const
 	{
-		br_sha1_out(&certificateSha1, hash);
-		return hash;
+		uint8_t certHash[br_sha1_SIZE];
+		br_sha1_out(&certificateSha1, certHash);
+		return memcmp(certHash, sha1Hash, br_sha1_SIZE) == 0;
+	}
+
+	bool matchPki(const uint8_t* hash) const
+	{
+		// @todo
+		return false;
 	}
 
 private:
@@ -113,8 +118,8 @@ private:
 	static const br_x509_class vt;
 	OnValidate onValidate;
 	br_sha1_context certificateSha1 = {};
-	br_sha256_context subjectSha256 = {};
-	br_sha256_context issuerSha256 = {};
+	X509Name issuer;
+	X509Name subject;
 	br_x509_decoder_context x509Decoder = {};
 	bool allowSelfSigned = false;
 	uint8_t certificateCount = 0;

--- a/Sming/Components/ssl/BearSsl/X509Name.cpp
+++ b/Sming/Components/ssl/BearSsl/X509Name.cpp
@@ -1,0 +1,54 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * X509Name.cpp
+ *
+ ****/
+
+#include <SslDebug.h>
+#include "X509Name.h"
+#include "Asn1Parser.h"
+
+namespace Ssl
+{
+void X509Name::append(const void* buf, size_t len)
+{
+	br_sha256_update(&sha256, buf, len);
+	dn.concat(static_cast<const char*>(buf), len);
+}
+
+String X509Name::getRDN(uint8_t type) const
+{
+	Asn1Parser parser(reinterpret_cast<const uint8_t*>(dn.c_str()), dn.length());
+
+	if(parser.getNextObject(ASN1_SEQUENCE) < 0) {
+		return nullptr;
+	}
+
+	unsigned len;
+	while((len = parser.getNextObject(ASN1_SET)) != 0) {
+		auto nextOffset = parser.getOffset() + len;
+
+		if(parser.getNextObject(ASN1_SEQUENCE) == 0) {
+			break;
+		}
+
+		int dn_type = parser.getObjectId();
+		if(dn_type < 0) {
+			break;
+		}
+
+		if(dn_type == type) {
+			return parser.getString();
+		}
+
+		parser.setOffset(nextOffset);
+	}
+
+	return nullptr;
+}
+
+} // namespace Ssl

--- a/Sming/Components/ssl/BearSsl/X509Name.h
+++ b/Sming/Components/ssl/BearSsl/X509Name.h
@@ -1,0 +1,67 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * X509Name.h
+ *
+ ****/
+
+#pragma once
+
+#include <bearssl.h>
+#include <WString.h>
+
+namespace Ssl
+{
+class X509Name
+{
+public:
+	X509Name() = default;
+
+	X509Name(const X509Name& name) : dn(name.dn)
+	{
+	}
+
+	X509Name(X509Name&& name) : dn(std::move(name.dn))
+	{
+	}
+
+	X509Name& operator=(X509Name&& name)
+	{
+		if(this != &name) {
+			dn = std::move(name.dn);
+		}
+		return *this;
+	}
+
+	void clear()
+	{
+		br_sha256_init(&sha256);
+		dn.setLength(0);
+	}
+
+	uint8_t* getHash(uint8_t hash[br_sha256_SIZE]) const
+	{
+		br_sha256_out(&sha256, hash);
+		return hash;
+	}
+
+	static void append(void* ctx, const void* buf, size_t len)
+	{
+		reinterpret_cast<X509Name*>(ctx)->append(buf, len);
+	}
+
+	// Obtain Relative Distinguished Name by type
+	String getRDN(uint8_t type) const;
+
+private:
+	void append(const void* buf, size_t len);
+
+private:
+	br_sha256_context sha256 = {};
+	String dn; ///< The ASN1-encoded Distinguished Name
+};
+
+} // namespace Ssl

--- a/Sming/Components/ssl/BearSsl/debug.h
+++ b/Sming/Components/ssl/BearSsl/debug.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#if !defined(SSL_DEBUG) && (DEBUG_VERBOSE_LEVEL >= 2)
-#undef DEBUG_VERBOSE_LEVEL
-#define DEBUG_VERBOSE_LEVEL 1
-#endif
-
-#include <debug_progmem.h>
-#include <assert.h>

--- a/Sming/Components/ssl/component.mk
+++ b/Sming/Components/ssl/component.mk
@@ -37,11 +37,6 @@ ifeq ($(ENABLE_SSL),0)
 	$(info SSL support disabled)
 else
 	$(info Using $(ENABLE_SSL) SSL implementation)
-endif
-
-COMPONENT_DOXYGEN_PREDEFINED := \
-	ENABLE_SSL=1
-
 
 # Application
 CUSTOM_TARGETS			+= include/ssl/private_key.h
@@ -55,3 +50,10 @@ include/ssl/private_key.h:
 	$(Q) mkdir -p $(SSL_INCLUDE_DIR) $(SSL_CERT_DIR)
 	$(Q) chmod a+x $(SSL_TOOLS_PATH)/make_certs.sh
 	cd $(SSL_CERT_DIR); SSL_INCLUDE_DIR=$(SSL_INCLUDE_DIR) $(SSL_TOOLS_PATH)/make_certs.sh
+
+endif
+
+COMPONENT_DOXYGEN_PREDEFINED := \
+	ENABLE_SSL=1
+
+

--- a/Sming/Components/ssl/include/Network/Ssl/Certificate.h
+++ b/Sming/Components/ssl/include/Network/Ssl/Certificate.h
@@ -14,6 +14,31 @@
 
 #include <WString.h>
 
+/**
+ * @brief X509 Relative Distinguished Name type
+ *
+ * From namespace 2.5.4.x
+ */
+#define SSL_X509_RDN_OID_MAP(XX)                                                                                       \
+	XX(COMMON_NAME, 2, 5, 4, 3)                                                                                        \
+	XX(SURNAME, 2, 5, 4, 4)                                                                                            \
+	XX(SERIAL_NUMBER, 2, 5, 4, 5)                                                                                      \
+	XX(COUNTRY_NAME, 2, 5, 4, 6)                                                                                       \
+	XX(LOCALITY_NAME, 2, 5, 4, 7)                                                                                      \
+	XX(STATE_OR_PROVINCE_NAME, 2, 5, 4, 8)                                                                             \
+	XX(STREET_ADDRESS, 2, 5, 4, 9)                                                                                     \
+	XX(ORGANIZATION_NAME, 2, 5, 4, 10)                                                                                 \
+	XX(ORGANIZATIONAL_UNIT_NAME, 2, 5, 4, 11)                                                                          \
+	XX(TITLE, 2, 5, 4, 12)                                                                                             \
+	XX(BUSINESS_CATEGORY, 2, 5, 4, 15)                                                                                 \
+	XX(POSTAL_ADDRESS, 2, 5, 4, 16)                                                                                    \
+	XX(POSTAL_CODE, 2, 5, 4, 17)                                                                                       \
+	XX(GIVEN_NAME, 2, 5, 4, 42)                                                                                        \
+	XX(GENERATION_QUALIFIER, 2, 5, 4, 44)                                                                              \
+	XX(X500_UNIQUE_IDENTIFIER, 2, 5, 4, 45)                                                                            \
+	XX(DN_QUALIFIER, 2, 5, 4, 46)                                                                                      \
+	XX(PSEUDONYM, 2, 5, 4, 65)
+
 namespace Ssl
 {
 /**
@@ -26,23 +51,24 @@ class Certificate
 {
 public:
 	/**
-	 * @brief List of distinguished names
-	 * @note Defined by AXTLS, other implementations will need to translate
+	 * @brief Distinguished Name type
 	 */
-	enum class Name {
-		CERT_COMMON_NAME,
-		CERT_ORGANIZATION,
-		CERT_ORGANIZATIONAL_NAME,
-		CERT_LOCATION,
-		CERT_COUNTRY,
-		CERT_STATE,
-		CA_CERT_COMMON_NAME,
-		CA_CERT_ORGANIZATION,
-		CA_CERT_ORGANIZATIONAL_NAME,
-		CA_CERT_LOCATION,
-		CA_CERT_COUNTRY,
-		CA_CERT_STATE,
+	enum class DN {
+		ISSUER,
+		SUBJECT,
 	};
+
+	/**
+	 * @brief Relative Distinguished Name type
+	 */
+	enum class RDN {
+#define XX(tag, a, b, c, d) tag,
+		SSL_X509_RDN_OID_MAP(XX)
+#undef XX
+			MAX
+	};
+
+	static String getRdnTypeString(Certificate::RDN rdn);
 
 	virtual ~Certificate()
 	{
@@ -67,7 +93,9 @@ public:
    * @param name the desired distinguished name
    * @retval the value for the desired distinguished name
    */
-	virtual const String getName(Name name) const = 0;
+	virtual String getName(DN dn, RDN rdn) const = 0;
+
+	size_t printTo(Print& p) const;
 };
 
 /** @} */

--- a/Sming/Components/ssl/include/SslDebug.h
+++ b/Sming/Components/ssl/include/SslDebug.h
@@ -1,0 +1,21 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SslDebug.h
+ *
+ * #include this file ahead of others to enable informational and debug messages only when SSL_DEBUG is defined.
+ *
+ ****/
+
+#pragma once
+
+#if !defined(SSL_DEBUG) && (DEBUG_VERBOSE_LEVEL >= 2)
+#undef DEBUG_VERBOSE_LEVEL
+#define DEBUG_VERBOSE_LEVEL 1
+#endif
+
+#include <debug_progmem.h>
+#include <assert.h>

--- a/Sming/Components/ssl/src/Certificate.cpp
+++ b/Sming/Components/ssl/src/Certificate.cpp
@@ -1,0 +1,45 @@
+#include <Network/Ssl/Certificate.h>
+#include <FlashString/Vector.hpp>
+
+namespace Ssl
+{
+#define XX(tag, a, b, c, d) DEFINE_FSTR_LOCAL(rdnStr_##tag, #tag)
+SSL_X509_RDN_OID_MAP(XX)
+#undef XX
+
+#define XX(tag, a, b, c, d) &rdnStr_##tag,
+DEFINE_FSTR_VECTOR_LOCAL(rdnStrings, FSTR::String, SSL_X509_RDN_OID_MAP(XX));
+#undef XX
+
+String Certificate::getRdnTypeString(Certificate::RDN rdn)
+{
+	return rdnStrings[unsigned(rdn)];
+}
+
+size_t Certificate::printTo(Print& p) const
+{
+	size_t n = 0;
+
+	auto printName = [&](DN dn) {
+		for(unsigned i = 0; i < unsigned(RDN::MAX); ++i) {
+			auto rdn = RDN(i);
+			auto s = getName(dn, rdn);
+			if(!s) {
+				continue;
+			}
+			n += p.print("  ");
+			n += p.print(getRdnTypeString(rdn));
+			n += p.print(": ");
+			n += p.println(s);
+		}
+	};
+
+	n += p.println(_F("Subject:"));
+	printName(DN::SUBJECT);
+	n += p.println(_F("Issuer:"));
+	printName(DN::ISSUER);
+
+	return n;
+}
+
+} // namespace Ssl

--- a/Sming/Components/ssl/src/Connection.cpp
+++ b/Sming/Components/ssl/src/Connection.cpp
@@ -8,6 +8,7 @@
  *
  ****/
 
+#include <SslDebug.h>
 #include <Network/Ssl/Context.h>
 #include <Print.h>
 
@@ -42,9 +43,7 @@ int Connection::writeTcpData(uint8_t* data, size_t length)
 	if(tcp_len < length) {
 		if(tcp_len == 0) {
 			tcp_output(tcp);
-#ifdef SSL_DEBUG
 			debug_e("writeTcpData: The send buffer is full! We have problem.");
-#endif
 			return 0;
 		}
 	} else {

--- a/Sming/Components/ssl/src/Connection.cpp
+++ b/Sming/Components/ssl/src/Connection.cpp
@@ -17,12 +17,11 @@ namespace Ssl
 size_t Connection::printTo(Print& p) const
 {
 	size_t n = 0;
-	n += p.println(_F("SSL Connection Information:"));
 	auto cert = getCertificate();
 	if(cert != nullptr) {
-		n += p.print(_F("  Certificate:  "));
-		n += p.println(cert->getName(Certificate::Name::CERT_COMMON_NAME));
+		n += cert->printTo(p);
 	}
+	n += p.println(_F("SSL Connection Information:"));
 	n += p.print(_F("  Cipher:       "));
 	n += p.println(getCipherSuiteName(getCipherSuite()));
 	n += p.print(_F("  Session ID:   "));

--- a/Sming/Components/ssl/src/InputBuffer.cpp
+++ b/Sming/Components/ssl/src/InputBuffer.cpp
@@ -8,6 +8,7 @@
  *
  ****/
 
+#include <SslDebug.h>
 #include <Network/Ssl/InputBuffer.h>
 
 namespace Ssl
@@ -21,11 +22,9 @@ size_t InputBuffer::read(uint8_t* buffer, size_t bufSize)
 	unsigned len = pbuf_copy_partial(buf, buffer, bufSize, offset);
 	offset += len;
 
-#ifdef SSL_DEBUG
 	if(len < bufSize) {
 		debug_d("SSL read input: Bytes needed: %d, Bytes read: %u", bufSize, len);
 	}
-#endif
 
 	return len;
 }

--- a/Sming/Components/ssl/src/Session.cpp
+++ b/Sming/Components/ssl/src/Session.cpp
@@ -8,6 +8,7 @@
  *
  ****/
 
+#include <SslDebug.h>
 #include <Network/Ssl/Session.h>
 #include <Network/Ssl/Factory.h>
 #include <Network/TcpConnection.h>
@@ -167,9 +168,7 @@ int Session::write(const uint8_t* data, size_t length)
 
 	int res = connection->write(data, length);
 	if(res < 0) {
-#ifdef SSL_DEBUG
 		debug_i("SSL: write returned %d (%s)", res, connection->getErrorString(res).c_str());
-#endif
 		return ERR_BUF;
 	}
 

--- a/Sming/Core/Network/TcpConnection.cpp
+++ b/Sming/Core/Network/TcpConnection.cpp
@@ -52,8 +52,12 @@ bool TcpConnection::sslCreateSession()
 	}
 
 	ssl = new Ssl::Session;
+	if(ssl == nullptr) {
+		return false;
+	}
 
-	return ssl != nullptr;
+	sslInitSession(*ssl);
+	return true;
 }
 
 bool TcpConnection::connect(const String& server, int port, bool useSsl)
@@ -388,9 +392,6 @@ err_t TcpConnection::internalOnConnected(err_t err)
 			debug_tcp_e("SSL disabled: aborting connection");
 			return ERR_ABRT;
 		}
-
-		sslInitSession(*ssl);
-
 		if(!ssl->onConnect(tcp)) {
 			return ERR_ABRT;
 		}

--- a/Sming/Core/Network/TcpServer.cpp
+++ b/Sming/Core/Network/TcpServer.cpp
@@ -88,9 +88,6 @@ err_t TcpServer::onAccept(tcp_pcb* clientTcp, err_t err)
 			delete client;
 			return ERR_ABRT;
 		}
-
-		sslInitSession(*ssl);
-
 		if(!ssl->onAccept(client, clientTcp)) {
 			delete client;
 			return ERR_ABRT;


### PR DESCRIPTION
Revise Distinguished Name interface so it's based more closely on the standard - as far as I can tell, as I don't have access to it!
Certificate, etc. shouldn't be built if ENABLE_SSL=0
Add common `SslDebug.h` to selectively enable INFO/DBG output only when SSL_DEBUG defined
For consistency, call `sslInitSession` from within `sslCreateSession`.
Further simplify TcpConnection::write.