### PR TITLE
Revise to work with Windows, and use `.cs` files for projects as well

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -108,6 +108,34 @@ $(CLEAN_TESTS):
 	$(Q) $(MAKE) -C $(@D) clean
 
 
+##@Developer
+
+# Recursive wildcard search
+# $1 -> list of directories
+# $2 -> file extensions filters (using % as wildcard)
+define rwildcard
+	$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $2,$d))
+endef
+
+# Files that should follow our coding standards
+
+# Root directories to search
+CS_ROOT_DIRS	?= $(abspath $(SMING_HOME)/..)
+# List of single directories to search
+CS_SEARCH_DIRS	?= $(call ListAllSubDirs,$(CS_ROOT_DIRS))
+# Resultant set of directories whose contents to apply coding style to
+CS_DIRS			?= $(patsubst %/.cs,%,$(wildcard $(foreach d,$(CS_SEARCH_DIRS),$d/.cs)))
+# Files to apply coding style to
+CS_FILES		= $(call rwildcard,$(CS_DIRS:=/*),%.cpp %.hpp %.h %.c)
+
+.PHONY: cs
+cs: ##Apply coding style to all core files
+	$(if $(V),$(info Applying coding style to $(words $(CS_FILES)) files ...))
+	@for FILE in $(CS_FILES); do \
+		$(CLANG_FORMAT) -i -style=file $$FILE; \
+	done
+
+
 ##@Help
 
 .PHONY: help

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -303,23 +303,3 @@ endef
 	$(Q) $(call TryApplyPatch,$*,$(*F).patch)
 	$(Q) touch $@
 
-##@Developer
-
-# Recursive wildcard search
-# $1 -> list of directories
-# $2 -> file extensions filters (using % as wildcard)
-define rwildcard
-	$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $2,$d))
-endef
-
-# Files that should follow our coding standards
-CS_DIRS		= $(shell find $(SMING_HOME)/../ -name '.cs' -type f  | xargs dirname)
-CS_FILES	= $(call rwildcard,$(CS_DIRS:=/*),%.cpp %.h %.c)
-
-.PHONY: cs
-cs: ##Apply coding style to all core files
-	$(if $(V),$(info Applying coding style to $(words $(CS_FILES)) files ...))
-	@for FILE in $(CS_FILES); do \
-		$(CLANG_FORMAT) -i -style=file $$FILE; \
-	done
-

--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -404,6 +404,12 @@ clean: ##Remove all generated build files (but leave build config intact)
 	@echo Cleaning application...
 	-$(Q) rm -rf $(BUILD_BASE) $(FW_BASE) $(APP_LIBDIR)
 
+.PHONY: cs
+cs: .clang-format ##Apply coding style to selected project directories
+	$(SMING_MAKE) cs CS_ROOT_DIRS=$(PROJECT_DIR)
+
+.clang-format:
+	$(Q) cp $(SMING_HOME)/../.clang-format $@
 
 ##@Tools
 


### PR DESCRIPTION
Projects don't need to set CS_DIRS, etc. in their component.mk.

If project hasn't already provided one, copies Sming's .clang-format file into project directory
on first use.