### PR TITLE
Change `FragmentSize` to `MaxBufferSize`

### DIFF
--- a/Sming/Components/ssl/Axtls/AxContext.cpp
+++ b/Sming/Components/ssl/Axtls/AxContext.cpp
@@ -78,7 +78,7 @@ Connection* AxContext::createClient(tcp_pcb* tcp)
 
 	auto ssl_ext = ssl_ext_new();
 	ssl_ext_set_host_name(ssl_ext, session.hostName.c_str());
-	ssl_ext_set_max_fragment_size(ssl_ext, session.fragmentSize);
+	ssl_ext_set_max_fragment_size(ssl_ext, unsigned(session.maxBufferSize));
 
 	auto id = session.getSessionId();
 	auto connection = new AxConnection(*this, tcp);

--- a/Sming/Components/ssl/BearSsl/BrClientConnection.cpp
+++ b/Sming/Components/ssl/BearSsl/BrClientConnection.cpp
@@ -23,9 +23,10 @@ int BrClientConnection::init()
 	br_ssl_client_zero(&clientContext);
 
 	// Use Mono-directional buffer size according to requested max. fragment size
-	auto fragSize = context.getSession().fragmentSize ?: eSEFS_4K;
-	size_t bufSize = (256U << fragSize) + (BR_SSL_BUFSIZE_MONO - 16384U);
-
+	size_t bufSize = maxBufferSizeToBytes(context.getSession().maxBufferSize);
+	if(bufSize == 0) {
+		bufSize = 4096;
+	}
 	int err = BrConnection::init(bufSize, false);
 	if(err < 0) {
 		return err;

--- a/Sming/Components/ssl/BearSsl/BrConnection.cpp
+++ b/Sming/Components/ssl/BearSsl/BrConnection.cpp
@@ -17,6 +17,10 @@
 #include <Network/Ssl/Session.h>
 #include <FlashString/Array.hpp>
 
+// Defined in ssl_engine.c
+#define MAX_OUT_OVERHEAD 85
+#define MAX_IN_OVERHEAD 325
+
 namespace Ssl
 {
 int BrConnection::init(size_t bufferSize, bool bidi)
@@ -82,6 +86,10 @@ int BrConnection::init(size_t bufferSize, bool bidi)
 	br_ssl_engine_set_default_des_cbc(engine);
 	br_ssl_engine_set_default_chapol(engine);
 
+	bufferSize += MAX_IN_OVERHEAD;
+	if(bidi) {
+		bufferSize += MAX_OUT_OVERHEAD;
+	}
 	debug_i("Using buffer size of %u bytes", bufferSize);
 	delete[] buffer;
 	buffer = new uint8_t[bufferSize];

--- a/Sming/Components/ssl/BearSsl/BrConnection.h
+++ b/Sming/Components/ssl/BearSsl/BrConnection.h
@@ -69,6 +69,11 @@ public:
 	}
 
 protected:
+	/**
+	 * Perform initialisation common to both client and server connections
+	 * @param bufferSize Buffer to allocate excluding overheads
+	 * @param bidi Whether to use bi-directional buffering (true) or mono
+	 */
 	int init(size_t bufferSize, bool bidi);
 
 	int runUntil(InputBuffer& input, unsigned target);

--- a/Sming/Components/ssl/BearSsl/BrServerConnection.cpp
+++ b/Sming/Components/ssl/BearSsl/BrServerConnection.cpp
@@ -22,10 +22,13 @@ int BrServerConnection::init()
 {
 	br_ssl_server_zero(&serverContext);
 
-	// Server requires bi-directional buffer, add on minimum size for output
-	auto fragSize = context.getSession().fragmentSize ?: eSEFS_4K;
-	size_t bufSize = (256U << fragSize) + (BR_SSL_BUFSIZE_MONO - 16384U);
-	bufSize += 512U + (BR_SSL_BUFSIZE_OUTPUT - 16384);
+	// Server requires bi-directional buffer
+	size_t bufSize = maxBufferSizeToBytes(context.getSession().maxBufferSize);
+	if(bufSize == 0) {
+		bufSize = 4096;
+	}
+	// add on minimum size for output
+	bufSize += 512U;
 
 	int err = BrConnection::init(bufSize, true);
 	if(err < 0) {

--- a/Sming/Components/ssl/include/Network/Ssl/Session.h
+++ b/Sming/Components/ssl/include/Network/Ssl/Session.h
@@ -20,22 +20,31 @@ class TcpConnection;
 namespace Ssl
 {
 /**
- * @brief Maximum Fragment Length Negotiation https://tools.ietf.org/html/rfc6066
+ * @brief Indicate to SSL how much memory (approximately) to commit for buffers
  *
- * 0,1,2,3..6 corresponding to off,512,1024,2048..16384 bytes
+ * A remote SSL server may require data transfers in large (16K) fragments,
+ * so restricting buffer sizes may cause connections to such servers to fail.
  *
- * The allowed values for this field are: 2^9, 2^10, 2^11, and 2^12
+ * This must be balanced against other requirements for RAM by the application,
+ * therefore this setting can be used to restrict RAM usage.
  *
+ * @note The ordinal value of this enumeration corresponds to SSL fragment size as defined in
+ * Maximum Fragment Length Negotiation https://tools.ietf.org/html/rfc6066
  */
-enum FragmentSize {
-	eSEFS_Off, ///< Let SSL implementation decide
-	eSEFS_512, ///< 512 bytes
-	eSEFS_1K,  ///< 1024 bytes
-	eSEFS_2K,
-	eSEFS_4K,
-	eSEFS_8K,
-	eSEFS_16K,
+enum class MaxBufferSize {
+	Default = 0, ///< Let SSL implementation decide
+	B512,		 ///< 512 bytes
+	K1,			 ///< 1024 bytes
+	K2,
+	K4,
+	K8,
+	K16,
 };
+
+__forceinline size_t maxBufferSizeToBytes(MaxBufferSize value)
+{
+	return (value == MaxBufferSize::Default) ? 0 : 256U << size_t(value);
+}
 
 /**
  * @brief Configurable options
@@ -67,7 +76,7 @@ public:
 	String hostName; ///< Used for SNI https://en.wikipedia.org/wiki/Server_Name_Indication
 	KeyCertPair keyCert;
 	Options options;
-	FragmentSize fragmentSize = eSEFS_Off; ///< Determines size of buffer required
+	MaxBufferSize maxBufferSize = MaxBufferSize::Default;
 	/**
 	 * Server: Number of cached client sessions. Suggested value: 10
 	 * Client: Number of cached session ids. Suggested value: 1

--- a/Sming/Components/ssl/src/Session.cpp
+++ b/Sming/Components/ssl/src/Session.cpp
@@ -140,7 +140,7 @@ void Session::close()
 	context = nullptr;
 
 	hostName = nullptr;
-	fragmentSize = eSEFS_Off;
+	maxBufferSize = MaxBufferSize::Default;
 }
 
 int Session::read(InputBuffer& input, uint8_t*& output)
@@ -223,8 +223,8 @@ size_t Session::printTo(Print& p) const
 	n += p.println(hostName);
 	n += p.print(_F("  Cache Size: "));
 	n += p.println(cacheSize);
-	n += p.print(_F("  Fragment Size: "));
-	n += p.println(fragmentSize);
+	n += p.print(_F("  Max Buffer Size: "));
+	n += p.println(maxBufferSizeToBytes(maxBufferSize));
 	n += p.print(_F("  Validators: "));
 	n += p.println(validators.count());
 	n += p.print(_F("  Cert Length: "));

--- a/samples/Basic_Ssl/app/application.cpp
+++ b/samples/Basic_Ssl/app/application.cpp
@@ -72,7 +72,8 @@ void grcSslInit(Ssl::Session& session, HttpRequest& request)
 	// We're using fingerprints, so don't attempt to validate full certificate
 	session.options.verifyLater = true;
 
-	session.fragmentSize = Ssl::eSEFS_16K;
+	// Go with maximum buffer sizes
+	session.maxBufferSize = Ssl::MaxBufferSize::K16;
 }
 
 void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)


### PR DESCRIPTION
The purpose of this value is allow applications to limit the buffer size and provide some control over RAM usage.

It is up to the SSL implementation/adapter how it is actually used.
At present we have max_fragment_length https://tools.ietf.org/html/rfc6066
but this will change to record_size_limit https://tools.ietf.org/html/rfc8449